### PR TITLE
Custom Field Word Delimiter

### DIFF
--- a/core/components/getrelated/elements/snippets/getrelated.properties.php
+++ b/core/components/getrelated/elements/snippets/getrelated.properties.php
@@ -24,6 +24,7 @@
 return array(
     'resource' => 'current',
     'fields' => 'pagetitle:3,introtext:2',
+    'wordDelimiter' => ' ',
     'returnFields' => 'pagetitle,longtitle,introtext',
     'returnTVs' => '',
 

--- a/core/components/getrelated/model/getrelated.class.php
+++ b/core/components/getrelated/model/getrelated.class.php
@@ -76,6 +76,9 @@ class getRelated {
         if (isset($a) && count($a) > 0) $this->config['parents'] = $a;
         $this->config['exclude'] = explode(',',$this->config['exclude']);
 
+        /* Delimiter used to explode each field */
+        $this->config['wordDelimiter'] = isset($this->config['wordDelimiter']) ? $this->config['wordDelimiter'] : ' ';
+
         $fields = explode(',',$this->config['fields']);
         foreach ($fields as $fld) {
             $tmp = explode(':',$fld);
@@ -172,7 +175,13 @@ class getRelated {
         /* Fetch resource data */
         $resValues = $this->resource->get($this->fields);
         $resValues = (is_array($resValues)) ? implode(' ',$resValues) : $resValues;
-        $resValues = explode(' ',trim($resValues));
+        if(!empty($this->config['wordDelimiter'])) {
+            $resValues = explode($this->config['wordDelimiter'],trim($resValues));
+        }
+        else {
+            // Handle case where empty delimiter is passed.
+            $resValues = array(trim($resValues));
+        }
 
         /* Combine the data and filter out duplicates, non-alphanum and stop words. */
         $values = array_merge($values,$resValues);


### PR DESCRIPTION
Having the ability to customize how `field` words are separated helps in at leach such cases where checking against entire phrases, may be desirable.

This pull request adds a `wordDelimiter` snippet property that allows for specification of a custom word delimiter for the resource field value(s), retaining the previous delimiter as default, and while still respecting the indistinct data check. There certainly may be a better way to do this, such as per-field word delimiter specification, but this is a start.